### PR TITLE
build(github-action): rename artifact name

### DIFF
--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -28,7 +28,7 @@ jobs:
         run: npm run build # 确保你的项目中定义了一个 "build" 脚本
 
       - name: Archive the build
-        run: zip -r build.zip ./dist # 将构建输出打包为 ZIP 文件
+        run: mv dist batch-move-files && zip -r build.zip ./batch-move-files # 将构建输出打包为 ZIP 文件
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
rename dist to obsidian plugin name, so that when unziped, we can move it directly.